### PR TITLE
feat: add static web app secrets retrieval for deployment token

### DIFF
--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -78,7 +78,14 @@ const backend = new containerapp.ContainerApp(`ca-${projectPrefix}-`, {
     },
 }, { dependsOn: [roleAssignment] });
  
+const staticWebAppSecrets = web.listStaticSiteSecretsOutput({
+    name: staticApp.name,
+    resourceGroupName: rg.name,
+});
 
+export const staticWebAppDeploymentToken = staticWebAppSecrets.apply(secrets =>
+    secrets.properties ? secrets.properties["apiKey"] : undefined
+);
 
 export const staticWebUrl = staticApp.defaultHostname;
 export const backendUrl = backend.latestRevisionFqdn.apply(fqdn => `https://${fqdn}`);


### PR DESCRIPTION
Added listStaticSiteSecrets to allow the pipeline to use the Static Web App deployment token.